### PR TITLE
Fix: Remove Deprecated `refresh-rate` option in `picom/picom.conf`

### DIFF
--- a/picom/picom.conf
+++ b/picom/picom.conf
@@ -83,7 +83,7 @@ mark-wmwin-focused = true;
 mark-ovredir-focused = true;
 detect-rounded-corners = true;
 detect-client-opacity = true;
-refresh-rate = 0;
+
 
 # use-ewmh-active-win = true;
 


### PR DESCRIPTION
The `refresh-rate` option is a option that can make i3 unstable.