### PR TITLE
Update i3status.conf

### DIFF
--- a/i3wm/i3status.conf
+++ b/i3wm/i3status.conf
@@ -19,8 +19,8 @@ order += "battery all"
 order += "tztime local"
 
 cpu_usage {
-        format= "CPU %usage"
-        max_threshold= 75
+        format = "CPU %usage"
+        max_threshold = 75
 }
 
 volume master {
@@ -56,7 +56,7 @@ battery all {
 }
 
 tztime local {
-        format = "%Y-%m-%d %I:%M:%S"
+        format = "%Y-%m-%d %H:%M:%S"
 }
 
 load {


### PR DESCRIPTION
There were no spaces with "format= "CPU %usage" and "max_threshold= 75". Also there was a %I instead of %H for time