### PR TITLE
fix broken sidebery hover in firefox v140

### DIFF
--- a/firefox/userChrome.css
+++ b/firefox/userChrome.css
@@ -101,7 +101,7 @@ html:not([privatebrowsingmode="temporary"]) #sidebar {
   min-width: var(--uc-sidebar-width) !important;
 }
 
-html:not([privatebrowsingmode="temporary"]) #sidebar-box:hover > #sidebar {
+html:not([privatebrowsingmode="temporary"]) #sidebar-box:hover > .sidebar-browser-stack > #sidebar {
   min-width: var(--uc-sidebar-hover-width) !important;
 }
 


### PR DESCRIPTION
the sidebery expand-on-hover behavior defined here breaks on the latest firefox update, leaving the sidebar permanently minimized to `--uc-sidebar-width` even when mousing over it. this fixes the issue and restores intended behavior (see [this discussion](https://codeberg.org/awwpotato/potatofox/issues/71))