### PR TITLE
nvim: fix telescope-fzf crash; ts_ls instead of tsserver

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -13,7 +13,7 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
-require("lazy").setup("plugins")
+require("lazy").setup("j.plugins")
 
 vim.o.background = "dark" -- or "light" for light mode
 vim.cmd([[colorscheme gruvbox]])

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -13,7 +13,7 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
-require("lazy").setup("j.plugins")
+require("lazy").setup("plugins")
 
 vim.o.background = "dark" -- or "light" for light mode
 vim.cmd([[colorscheme gruvbox]])
@@ -21,9 +21,6 @@ vim.cmd([[colorscheme gruvbox]])
 vim.opt.clipboard = 'unnamedplus'
 vim.opt.number = true
 vim.opt.relativenumber = true
-vim.opt.expandtab = true
-vim.opt.shiftwidth = 2
-vim.opt.tabstop = 2
 vim.opt.expandtab = true
 vim.opt.shiftwidth = 2
 vim.opt.tabstop = 2

--- a/nvim/lua/j/plugins/lsp-zero.lua
+++ b/nvim/lua/j/plugins/lsp-zero.lua
@@ -105,10 +105,11 @@ return {
             local lua_opts = lsp_zero.nvim_lua_ls()
             require('lspconfig').lua_ls.setup(lua_opts)
           end,
-          tsserver = function()
-            require('lspconfig').tsserver.setup({
+
+          -- 'tsserver', has been renamed to 'ts_ls'
+          ts_ls = function()
+            require('lspconfig').ts_ls.setup({
               on_attach = function(client, bufnr)
-                -- Add any specific settings for tsserver here
                 lsp_zero.default_keymaps({buffer = bufnr})
               end,
             })

--- a/nvim/lua/j/plugins/telescope.lua
+++ b/nvim/lua/j/plugins/telescope.lua
@@ -2,11 +2,11 @@ return {
   {
 	'nvim-telescope/telescope.nvim',
 	dependencies = {
-		{ 'BurntSushi/ripgrep', 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' }
+		{ 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' }
 	},
 	config = function(lazy, opts) 
 		local telescope = require('telescope')
-		telescope.load_extension('fzf')
+		pcall(telescope.load_extension, 'fzf')
 		telescope.setup({
 			defaults = {
 				wrap_result = true,


### PR DESCRIPTION
init.lua: tidy
telescrope.lua: warp 'load_extension(fzf)', safety loading on the fresh first_boot.
telescrope.lua: remove non-plugin 'ripgrep' from deps.
lsp-zero.lua: rename 'tsserver' handler to 'ts_ls'